### PR TITLE
feat: add live updates via Capawesome Cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CAPAWESOME_CLI_VERSION: 4.9.3
+  CAPAWESOME_CLOUD_APP_ID: 70922e93-0944-48cc-a560-61135ab291ad
   NODE_VERSION: 24
 
 jobs:
@@ -29,7 +30,7 @@ jobs:
       - name: Build Android
         run: |
           npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} apps:builds:create \
-            --app-id ${{ secrets.CAPAWESOME_CLOUD_APP_ID }} \
+            --app-id ${{ env.CAPAWESOME_CLOUD_APP_ID }} \
             --platform android \
             --type release \
             --git-ref ${{ github.event.pull_request.head.sha || github.sha }} \
@@ -48,7 +49,7 @@ jobs:
       - name: Build iOS
         run: |
           npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} apps:builds:create \
-            --app-id ${{ secrets.CAPAWESOME_CLOUD_APP_ID }} \
+            --app-id ${{ env.CAPAWESOME_CLOUD_APP_ID }} \
             --platform ios \
             --type development \
             --git-ref ${{ github.event.pull_request.head.sha || github.sha }} \

--- a/.github/workflows/live-update.yml
+++ b/.github/workflows/live-update.yml
@@ -1,0 +1,34 @@
+name: Live Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Channel name to deploy the live update to'
+        required: true
+        type: string
+
+env:
+  CAPAWESOME_CLI_VERSION: 4.9.3
+  CAPAWESOME_CLOUD_APP_ID: 70922e93-0944-48cc-a560-61135ab291ad
+  NODE_VERSION: 24
+
+jobs:
+  deploy-live-update:
+    name: Deploy Live Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Authenticate with Capawesome Cloud
+        run: npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} login --token ${{ secrets.CAPAWESOME_CLOUD_TOKEN }}
+      - name: Build and deploy live update
+        run: |
+          npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} apps:builds:create \
+            --app-id ${{ env.CAPAWESOME_CLOUD_APP_ID }} \
+            --platform web \
+            --channel "${{ inputs.channel }}" \
+            --git-ref ${{ github.sha }} \
+            --yes

--- a/.github/workflows/live-update.yml
+++ b/.github/workflows/live-update.yml
@@ -25,10 +25,12 @@ jobs:
       - name: Authenticate with Capawesome Cloud
         run: npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} login --token ${{ secrets.CAPAWESOME_CLOUD_TOKEN }}
       - name: Build and deploy live update
+        env:
+          CHANNEL: ${{ inputs.channel }}
         run: |
           npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} apps:builds:create \
             --app-id ${{ env.CAPAWESOME_CLOUD_APP_ID }} \
             --platform web \
-            --channel "${{ inputs.channel }}" \
+            --channel "$CHANNEL" \
             --git-ref ${{ github.sha }} \
             --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   CAPAWESOME_CLI_VERSION: 4.9.3
+  CAPAWESOME_CLOUD_APP_ID: 70922e93-0944-48cc-a560-61135ab291ad
   NODE_VERSION: 24
 
 jobs:
@@ -21,7 +22,7 @@ jobs:
       - name: Build and deploy Android
         run: |
           npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} apps:builds:create \
-            --app-id ${{ secrets.CAPAWESOME_CLOUD_APP_ID }} \
+            --app-id ${{ env.CAPAWESOME_CLOUD_APP_ID }} \
             --platform android \
             --type release \
             --git-ref ${{ github.sha }} \
@@ -41,7 +42,7 @@ jobs:
       - name: Build and deploy iOS
         run: |
           npx @capawesome/cli@${{ env.CAPAWESOME_CLI_VERSION }} apps:builds:create \
-            --app-id ${{ secrets.CAPAWESOME_CLOUD_APP_ID }} \
+            --app-id ${{ env.CAPAWESOME_CLOUD_APP_ID }} \
             --platform ios \
             --type app-store \
             --git-ref ${{ github.sha }} \

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,6 +15,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 60003
         versionName "6.0.3"
+        resValue "string", "capawesome_live_update_default_channel", "production-" + defaultConfig.versionCode
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(':capawesome-team-capacitor-file-opener')
     implementation project(':capawesome-team-capacitor-nfc')
     implementation project(':capawesome-capacitor-android-edge-to-edge-support')
+    implementation project(':capawesome-capacitor-live-update')
 
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    >
-
+<?xml version="1.0" encoding="utf-8" ?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -9,7 +7,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-
         <activity
             android:exported="true"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"
@@ -17,12 +14,10 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask">
-
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
         </activity>
 
         <provider
@@ -30,9 +25,7 @@
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths"></meta-data>
+            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
         </provider>
     </application>
 

--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -17,6 +17,13 @@
 		"EdgeToEdge": {
 			"backgroundColor": "#e2001a"
 		},
+		"LiveUpdate": {
+			"appId": "70922e93-0944-48cc-a560-61135ab291ad",
+			"autoUpdateStrategy": "background",
+			"readyTimeout": 10000,
+			"autoBlockRolledBackBundles": true,
+			"serverDomain": "api.cloud.capawesome.eu"
+		},
 		"SplashScreen": {
 			"showSpinner": false,
 			"splashFullScreen": true,

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -42,5 +42,9 @@
 	{
 		"pkg": "@capawesome/capacitor-android-edge-to-edge-support",
 		"classpath": "io.capawesome.capacitorjs.plugins.androidedgetoedgesupport.EdgeToEdgePlugin"
+	},
+	{
+		"pkg": "@capawesome/capacitor-live-update",
+		"classpath": "io.capawesome.capacitorjs.plugins.liveupdate.LiveUpdatePlugin"
 	}
 ]

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -34,3 +34,6 @@ project(':capawesome-team-capacitor-nfc').projectDir = new File('../node_modules
 
 include ':capawesome-capacitor-android-edge-to-edge-support'
 project(':capawesome-capacitor-android-edge-to-edge-support').projectDir = new File('../node_modules/@capawesome/capacitor-android-edge-to-edge-support/android')
+
+include ':capawesome-capacitor-live-update'
+project(':capawesome-capacitor-live-update').projectDir = new File('../node_modules/@capawesome/capacitor-live-update/android')

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -17,6 +17,13 @@
     "EdgeToEdge": {
       "backgroundColor": "#e2001a"
     },
+    "LiveUpdate": {
+      "appId": "70922e93-0944-48cc-a560-61135ab291ad",
+      "autoBlockRolledBackBundles": true,
+      "autoUpdateStrategy": "background",
+      "readyTimeout": 10000,
+      "serverDomain": "api.cloud.capawesome.eu"
+    },
     "SplashScreen": {
       "showSpinner": false,
       "splashFullScreen": true,

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		A1B2C3D40000000000000001 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000002 /* PrivacyInfo.xcprivacy */; };
 		A084ECDBA7D38E1E42DFC39D /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */; };
 /* End PBXBuildFile section */
 
@@ -27,6 +28,7 @@
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
+		A1B2C3D40000000000000002 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		7C07B6D22B91FB6C00652B63 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.release.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.release.xcconfig"; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
 				504EC3131FED79650016851F /* Info.plist */,
+				A1B2C3D40000000000000002 /* PrivacyInfo.xcprivacy */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
 			);
@@ -124,8 +127,8 @@
 		504EC2FC1FED79650016851F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0920;
+				LastSwiftUpdateCheck = 920;
+				LastUpgradeCheck = 920;
 				TargetAttributes = {
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
@@ -163,6 +166,7 @@
 				50379B232058CBB4000EE86E /* capacitor.config.json in Resources */,
 				504EC30D1FED79650016851F /* Main.storyboard in Resources */,
 				2FAD9763203C412B000D30F8 /* config.xml in Resources */,
+				A1B2C3D40000000000000001 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -289,6 +293,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				CURRENT_PROJECT_VERSION = 60003;
 			};
 			name = Debug;
 		};
@@ -339,6 +344,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
+				CURRENT_PROJECT_VERSION = 60003;
 			};
 			name = Release;
 		};
@@ -361,6 +367,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				MARKETING_VERSION = 6.0.3;
 			};
 			name = Debug;
 		};
@@ -382,6 +389,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				MARKETING_VERSION = 6.0.3;
 			};
 			name = Release;
 		};

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -17,9 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.3</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>60003</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CapawesomeLiveUpdateDefaultChannel</key>
+	<string>production-$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ios/App/App/PrivacyInfo.xcprivacy
+++ b/ios/App/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -17,6 +17,13 @@
 		"EdgeToEdge": {
 			"backgroundColor": "#e2001a"
 		},
+		"LiveUpdate": {
+			"appId": "70922e93-0944-48cc-a560-61135ab291ad",
+			"autoUpdateStrategy": "background",
+			"readyTimeout": 10000,
+			"autoBlockRolledBackBundles": true,
+			"serverDomain": "api.cloud.capawesome.eu"
+		},
 		"SplashScreen": {
 			"showSpinner": false,
 			"splashFullScreen": true,
@@ -35,6 +42,7 @@
 		"StatusBarPlugin",
 		"FileOpenerPlugin",
 		"NfcPlugin",
+		"LiveUpdatePlugin",
 		"CDVPlugin"
 	]
 }

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -21,6 +21,7 @@ def capacitor_pods
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
   pod 'CapawesomeTeamCapacitorFileOpener', :path => '../../node_modules/@capawesome-team/capacitor-file-opener'
   pod 'CapawesomeTeamCapacitorNfc', :path => '../../node_modules/@capawesome-team/capacitor-nfc'
+  pod 'CapawesomeCapacitorLiveUpdate', :path => '../../node_modules/@capawesome/capacitor-live-update'
   pod 'CordovaPlugins', :path => '../capacitor-cordova-ios-plugins'
 end
 

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - Alamofire (5.10.2)
   - Capacitor (8.2.0):
     - CapacitorCordova
   - CapacitorActionSheet (8.1.0):
@@ -18,12 +19,17 @@ PODS:
     - Capacitor
   - CapacitorStatusBar (8.0.1):
     - Capacitor
+  - CapawesomeCapacitorLiveUpdate (8.2.2):
+    - Alamofire (~> 5.10.2)
+    - Capacitor
+    - ZIPFoundation (~> 0.9.0)
   - CapawesomeTeamCapacitorFileOpener (8.0.1):
     - Capacitor
   - CapawesomeTeamCapacitorNfc (8.0.1):
     - Capacitor
   - CordovaPlugins (8.2.0):
     - CapacitorCordova
+  - ZIPFoundation (0.9.20)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -36,9 +42,15 @@ DEPENDENCIES:
   - "CapacitorShare (from `../../node_modules/@capacitor/share`)"
   - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
+  - "CapawesomeCapacitorLiveUpdate (from `../../node_modules/@capawesome/capacitor-live-update`)"
   - "CapawesomeTeamCapacitorFileOpener (from `../../node_modules/@capawesome-team/capacitor-file-opener`)"
   - "CapawesomeTeamCapacitorNfc (from `../../node_modules/@capawesome-team/capacitor-nfc`)"
   - CordovaPlugins (from `../capacitor-cordova-ios-plugins`)
+
+SPEC REPOS:
+  trunk:
+    - Alamofire
+    - ZIPFoundation
 
 EXTERNAL SOURCES:
   Capacitor:
@@ -61,6 +73,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/splash-screen"
   CapacitorStatusBar:
     :path: "../../node_modules/@capacitor/status-bar"
+  CapawesomeCapacitorLiveUpdate:
+    :path: "../../node_modules/@capawesome/capacitor-live-update"
   CapawesomeTeamCapacitorFileOpener:
     :path: "../../node_modules/@capawesome-team/capacitor-file-opener"
   CapawesomeTeamCapacitorNfc:
@@ -69,6 +83,7 @@ EXTERNAL SOURCES:
     :path: "../capacitor-cordova-ios-plugins"
 
 SPEC CHECKSUMS:
+  Alamofire: 7193b3b92c74a07f85569e1a6c4f4237291e7496
   Capacitor: 49a454e1cdbd520bc106a220adca7913536a4933
   CapacitorActionSheet: beba4b3fc77fb7ef4a532ee07fa90180855041e0
   CapacitorApp: 942306cd1acf7774a00e89a3986af3a67c8cad7a
@@ -79,10 +94,12 @@ SPEC CHECKSUMS:
   CapacitorShare: 0c58305114538568059bfc07111f22dcb9cb2a82
   CapacitorSplashScreen: 4b46c72298db552b3c57ce021ef028b6dc7f1fa7
   CapacitorStatusBar: 32206abd53b14f339763da26f71286deaa891e16
+  CapawesomeCapacitorLiveUpdate: 7a7dfe0e2c81a3095477f97290f98194ca355ab4
   CapawesomeTeamCapacitorFileOpener: 4b1c1a5a739915ed692296c5a7760903ca6ffa25
   CapawesomeTeamCapacitorNfc: 707034c3aeace18fca0516b05043d7483fba4f23
   CordovaPlugins: 607152f73690dca4bc10ab75e9194c2f10881d3a
+  ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 
-PODFILE CHECKSUM: a136ffc1f3f43b209a52690d69a69d9bb0d7a6e9
+PODFILE CHECKSUM: b51d76c6ff0fdb28bbe3345086747d61d8a5fe92
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@capawesome-team/capacitor-file-opener": "8.0.1",
         "@capawesome-team/capacitor-nfc": "8.0.1",
         "@capawesome/capacitor-android-edge-to-edge-support": "8.0.6",
+        "@capawesome/capacitor-live-update": "8.2.2",
         "@fortawesome/angular-fontawesome": "4.0.0",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
@@ -78,7 +79,7 @@
         "@angular/compiler-cli": "21.2.13",
         "@angular/language-service": "21.2.13",
         "@capacitor/cli": "8.2.0",
-        "@capawesome/capver": "0.1.3",
+        "@capawesome/capver": "0.1.4",
         "@cypress/schematic": "2.5.1",
         "@ionic/angular-toolkit": "12.3.0",
         "@ionic/cli": "7.2.0",
@@ -3453,10 +3454,29 @@
         "@capacitor/core": ">=8.0.0"
       }
     },
+    "node_modules/@capawesome/capacitor-live-update": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@capawesome/capacitor-live-update/-/capacitor-live-update-8.2.2.tgz",
+      "integrity": "sha512-jzBKG5dAVnVHaJwYpaiqmFdPY4uyVoLhPaNEWXyDO49kTZJtwiewXgYKFhpc+5VgpD5e7e6gb2Amg1sxZTGpdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capawesome/capver": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@capawesome/capver/-/capver-0.1.3.tgz",
-      "integrity": "sha512-pvk/7DtsWqlctIjKw/hKMDKczDPBPV3lzvLGB8Bf99KbWjt6CF+DUj16r2EHTuIziInSzJmtBUd284egjqoBRw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@capawesome/capver/-/capver-0.1.4.tgz",
+      "integrity": "sha512-FY3zre+9A3yeBHf1fXCvjUyAcH0RsEmJL4pvHwB4uAlOZDrIbWmQWQQTrseKk4+tVFjM+uhFY2Pqqe0hLm5UdA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@capawesome-team/capacitor-file-opener": "8.0.1",
     "@capawesome-team/capacitor-nfc": "8.0.1",
     "@capawesome/capacitor-android-edge-to-edge-support": "8.0.6",
+    "@capawesome/capacitor-live-update": "8.2.2",
     "@fortawesome/angular-fontawesome": "4.0.0",
     "@fortawesome/fontawesome-svg-core": "6.5.1",
     "@fortawesome/free-brands-svg-icons": "6.5.1",
@@ -92,7 +93,7 @@
     "@angular/compiler-cli": "21.2.13",
     "@angular/language-service": "21.2.13",
     "@capacitor/cli": "8.2.0",
-    "@capawesome/capver": "0.1.3",
+    "@capawesome/capver": "0.1.4",
     "@cypress/schematic": "2.5.1",
     "@ionic/angular-toolkit": "12.3.0",
     "@ionic/cli": "7.2.0",
@@ -143,7 +144,7 @@
   },
   "commit-and-tag-version": {
     "scripts": {
-      "postbump": "npx @capawesome/capver set $(node -p \"require('./package.json').version\") && git add android/app/build.gradle ios/App/App/Info.plist"
+      "postbump": "npx @capawesome/capver set $(node -p \"require('./package.json').version\") && git add android/app/build.gradle ios/App/App/Info.plist ios/App/App.xcodeproj/project.pbxproj"
     }
   },
   "elf": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   },
   "commit-and-tag-version": {
     "scripts": {
-      "postbump": "npx @capawesome/capver set $(node -p \"require('./package.json').version\") && git add android/app/build.gradle ios/App/App/Info.plist ios/App/App.xcodeproj/project.pbxproj"
+      "postbump": "npx @capawesome/capver set $(node -p \"require('./package.json').version\") && git add android/app/build.gradle ios/App/App.xcodeproj/project.pbxproj"
     }
   },
   "elf": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { Capacitor } from '@capacitor/core';
 import { SplashScreen } from '@capacitor/splash-screen';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { MenuController } from '@ionic/angular';
-import { CapacitorAppService, TimeoutService } from './core';
+import { CapacitorAppService, CapacitorLiveUpdateService, DialogService, TimeoutService } from './core';
 
 @Component({
   selector: 'app-root',
@@ -15,9 +15,12 @@ export class AppComponent {
   constructor(
     private readonly menuController: MenuController,
     private readonly timeoutService: TimeoutService,
+    private readonly capacitorLiveUpdateService: CapacitorLiveUpdateService,
+    private readonly dialogService: DialogService,
     // Do NOT remove the following services:
     private readonly capacitorAppService: CapacitorAppService,
   ) {
+    this.initializeLiveUpdate();
     void this.initializeApp();
   }
 
@@ -27,6 +30,22 @@ export class AppComponent {
 
   public openWindow(url: string): any {
     return window.open(url, '_self');
+  }
+
+  private initializeLiveUpdate(): void {
+    void this.capacitorLiveUpdateService.ready();
+    this.capacitorLiveUpdateService.nextBundleSet$.subscribe(async event => {
+      if (!event.bundleId) {
+        return;
+      }
+      const confirmed = await this.dialogService.showConfirmAlert({
+        header: 'Update verfügbar',
+        message: 'Eine neue Version der App ist verfügbar. Möchten Sie das Update jetzt installieren?',
+      });
+      if (confirmed) {
+        await this.capacitorLiveUpdateService.reload();
+      }
+    });
   }
 
   private async initializeApp(): Promise<void> {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,6 +33,9 @@ export class AppComponent {
   }
 
   private initializeLiveUpdate(): void {
+    if (!Capacitor.isNativePlatform()) {
+      return;
+    }
     void this.capacitorLiveUpdateService.ready();
     this.capacitorLiveUpdateService.nextBundleSet$.subscribe(async event => {
       if (!event.bundleId) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,7 +43,7 @@ export class AppComponent {
       }
       const confirmed = await this.dialogService.showConfirmAlert({
         header: 'Update verfügbar',
-        message: 'Eine neue Version der App ist verfügbar. Möchten Sie das Update jetzt installieren?',
+        message: 'Eine neue Version der App ist verfügbar. Möchtest du das Update jetzt installieren?',
       });
       if (confirmed) {
         await this.capacitorLiveUpdateService.reload();

--- a/src/app/core/services/capacitor/capacitor-live-update/capacitor-live-update.service.ts
+++ b/src/app/core/services/capacitor/capacitor-live-update/capacitor-live-update.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, NgZone } from '@angular/core';
+import { LiveUpdate, NextBundleSetEvent } from '@capawesome/capacitor-live-update';
+import { Observable, Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CapacitorLiveUpdateService {
+  private readonly nextBundleSetSubject = new Subject<NextBundleSetEvent>();
+
+  constructor(private readonly ngZone: NgZone) {
+    void LiveUpdate.removeAllListeners().then(() => {
+      void LiveUpdate.addListener('nextBundleSet', event => {
+        this.ngZone.run(() => {
+          this.nextBundleSetSubject.next(event);
+        });
+      });
+    });
+  }
+
+  public get nextBundleSet$(): Observable<NextBundleSetEvent> {
+    return this.nextBundleSetSubject.asObservable();
+  }
+
+  public async ready(): Promise<void> {
+    await LiveUpdate.ready();
+  }
+
+  public async reload(): Promise<void> {
+    await LiveUpdate.reload();
+  }
+}

--- a/src/app/core/services/capacitor/index.ts
+++ b/src/app/core/services/capacitor/index.ts
@@ -1,2 +1,3 @@
 export * from './capacitor-app/capacitor-app.service';
+export * from './capacitor-live-update/capacitor-live-update.service';
 export * from './capacitor-nfc/capacitor-nfc.service';


### PR DESCRIPTION
## Summary

Add Live Updates via Capawesome Cloud, with versioned channels tied to the iOS / Android version code, rollback protection, and a workflow for ad-hoc deploys.

## Changes

- Install and configure `@capawesome/capacitor-live-update` (EU region via `serverDomain: api.cloud.capawesome.eu`, `autoUpdateStrategy: "background"`, `readyTimeout: 10000`, `autoBlockRolledBackBundles: true`).
- Wire `LiveUpdate.ready()` and a `nextBundleSet` listener in `AppComponent.initializeLiveUpdate()`, prompting the user via `DialogService.showConfirmAlert` before reloading.
- Wrap the plugin in `CapacitorLiveUpdateService` (mirrors `CapacitorNfcService`) exposing `ready()`, `reload()`, and a `nextBundleSet$` observable.
- Versioned channels: Android `resValue` derived from `defaultConfig.versionCode`, iOS `CapawesomeLiveUpdateDefaultChannel = production-$(CURRENT_PROJECT_VERSION)`.
- Bump `@capawesome/capver` to 0.1.4, which now preserves Trapeze's `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)` references in `Info.plist` instead of overwriting with literals. Drop the temporary postbump sync hack.
- Add `ios/App/App/PrivacyInfo.xcprivacy` declaring the UserDefaults reason `CA92.1` required by the live-update SDK; wire it into the Xcode project.
- Add `.github/workflows/live-update.yml` — `workflow_dispatch` with a required `channel` input that runs `apps:builds:create --platform web --channel <input>` against Capawesome Cloud.
- Move `CAPAWESOME_CLOUD_APP_ID` from a GitHub secret to a workflow `env:` variable across all workflows (the ID is already visible in `capacitor.config.json`).

## Test plan

- [ ] Run `Live Update` workflow against the `test` channel and verify a bundle reaches a dev install.
- [ ] Bump to a new version via `npm run release` and confirm the matching `production-<versionCode>` channel exists in Capawesome Cloud before publishing.
- [ ] Verify the update prompt (Ionic alert, German wording) appears on a device when a new bundle is downloaded.
